### PR TITLE
Support for multiple add and remove listener functions

### DIFF
--- a/docs/rules/matching-remove-event-listener.md
+++ b/docs/rules/matching-remove-event-listener.md
@@ -6,6 +6,9 @@ This rule enforces that the handler for a `removeEventListener` is the same hand
 
 Note that if the `addListener` specifies the `useCapture` argument, so must the `removeEventListener` for it to match and be removed as expected
 
+EventEmitters with `addListener` and `removeListener` are also supported. If the `removeAllListeners` function is called, a matching
+`removeListener` is not required. The `on` and `off` alias are also supported.
+
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -52,6 +55,24 @@ class App {
 }
 ```
 
+```js
+const emitter = new EventEmitter()
+
+const dataHandler = () => {
+  console.log('data')
+}
+const data2Handler = () => {
+  console.log('data')
+}
+
+emitter.on('data', dataHandler)
+
+emitter.once('close', () => {
+  console.log('close')
+  emitter.removeListener('data', dataHandler2)
+})
+```
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -96,4 +117,22 @@ class App {
     return null;
   }
 }
+```
+
+```js
+const emitter = new EventEmitter()
+
+const dataHandler = () => {
+  console.log('data')
+}
+const data2Handler = () => {
+  console.log('data')
+}
+
+emitter.on('data', dataHandler)
+
+emitter.once('close', () => {
+  console.log('close')
+  emitter.removeListener('data', dataHandler)
+})
 ```

--- a/docs/rules/no-inline-function-event-listener.md
+++ b/docs/rules/no-inline-function-event-listener.md
@@ -4,6 +4,9 @@
 
 This rule enforces that the handlers for `addEventListener` are not inline functions
 
+EventEmitters with `addListener` and `removeListener` are also supported. If the `removeAllListeners` function is called, a matching
+`removeListener` is not required. The `on` and `off` alias are also supported.
+
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -39,6 +42,25 @@ class App {
 }
 ```
 
+```js
+const handleData = () => {
+  console.log('some data')
+}
+
+class Handler {
+  constructor(private readonly emitter: EventEmitter) {
+    emitter.on('data', handleData)
+    emitter.on('error', (error) => {
+      console.log('some error', error)
+    })
+  }
+
+  destroy() {
+    this.emitter.removeAllListeners()
+  }
+}
+```
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -65,6 +87,27 @@ class App {
     return (
       <div ref={node => this.rootNodeRef = node} />
     )
+  }
+}
+```
+
+```js
+const handleData = () => {
+  console.log('some data')
+}
+const handleError = (error) => {
+  console.log('some error', error)
+}
+
+class Handler {
+  constructor(private readonly emitter: EventEmitter) {
+    emitter.on('data', handleData)
+    emitter.on('error', handleError)
+  }
+
+  destroy() {
+    this.emitter.off('data', handleData)
+    this.emitter.off('error', handleError)       
   }
 }
 ```

--- a/docs/rules/no-missing-remove-event-listener.md
+++ b/docs/rules/no-missing-remove-event-listener.md
@@ -4,6 +4,9 @@
 
 This rule enforces that there be a `removeEventListener` for all events that have an `addEventListener` attached
 
+EventEmitters with `addListener` and `removeListener` are also supported. If the `removeAllListeners` function is called, a matching
+`removeListener` is not required. The `on` and `off` alias are also supported.
+
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -22,6 +25,20 @@ class App {
     )
   }
 }
+```
+
+```js
+const emitter = new EventEmitter()
+
+const dataHandler = () => {
+  console.log('data')
+}
+
+emitter.on('data', dataHandler)
+
+emitter.once('close', () => {
+  console.log('close')
+})
 ```
 
 Examples of **correct** code for this rule:
@@ -46,4 +63,19 @@ class App {
     )
   }
 }
+```
+
+```js
+const emitter = new EventEmitter()
+
+const dataHandler = () => {
+  console.log('data')
+}
+
+emitter.on('data', dataHandler)
+
+emitter.once('close', () => {
+  console.log('close')
+  emitter.off('data', dataHandler)
+})
 ```

--- a/tests/lib/tests/src/rules/matching-remove-event-listener.js
+++ b/tests/lib/tests/src/rules/matching-remove-event-listener.js
@@ -75,6 +75,25 @@ ruleTester.run('matching-remove-event-listener', (0, event_listener_1.createRule
       }
     `,
         },
+        {
+            code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+      const data2Handler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.removeListener('data', dataHandler)
+      })
+      `,
+        },
     ],
     invalid: [
         {
@@ -214,6 +233,36 @@ ruleTester.run('matching-remove-event-listener', (0, event_listener_1.createRule
                         remove: 'clickHandler',
                         element: 'this.rootNodeRef',
                         eventName: 'click',
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+      const data2Handler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.removeListener('data', dataHandler2)
+      })
+      `,
+            errors: [
+                {
+                    messageId: 'listenersDoNotMatch',
+                    data: {
+                        add: 'dataHandler',
+                        remove: 'dataHandler2',
+                        element: 'emitter',
+                        eventName: 'data',
                     },
                 },
             ],

--- a/tests/lib/tests/src/rules/no-inline-function-event-listener.js
+++ b/tests/lib/tests/src/rules/no-inline-function-event-listener.js
@@ -47,6 +47,28 @@ ruleTester.run('inline-function-event-listener', (0, event_listener_1.createRule
       }
     `,
         },
+        {
+            code: `
+      const handleData = () => {
+        console.log('some data')
+      }
+      const handleError = (error) => {
+        console.log('some error', error)
+      }
+
+      class Handler {
+        constructor(private readonly emitter: EventEmitter) {
+          emitter.on('data', handleData)
+          emitter.on('error', handleError)
+        }
+
+        destroy() {
+          this.emitter.off('data', handleData)
+          this.emitter.off('error', handleError)       
+        }
+      }
+    `,
+        },
     ],
     invalid: [
         {
@@ -97,6 +119,37 @@ ruleTester.run('inline-function-event-listener', (0, event_listener_1.createRule
                         element: 'this.rootNodeRef',
                         eventName: 'tap',
                         type: 'plain function',
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+      const handleData = () => {
+        console.log('some data')
+      }
+
+      class Handler {
+        constructor(private readonly emitter: EventEmitter) {
+          emitter.on('data', handleData)
+          emitter.on('error', (error) => {
+            console.log('some error', error)
+          })
+        }
+
+        destroy() {
+          this.emitter.off('data', handleData)
+          this.emitter.removeAllListeners()
+        }
+      }
+      `,
+            errors: [
+                {
+                    messageId: 'prohibitedListener',
+                    data: {
+                        element: 'emitter',
+                        eventName: 'error',
+                        type: 'arrow function',
                     },
                 },
             ],

--- a/tests/lib/tests/src/rules/no-missing-remove-event-listener.js
+++ b/tests/lib/tests/src/rules/no-missing-remove-event-listener.js
@@ -70,6 +70,22 @@ ruleTester.run('no-missing-remove-event-listener', (0, event_listener_1.createRu
     }
     `,
         },
+        {
+            code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.off('data', dataHandler)
+      })
+      `,
+        },
     ],
     invalid: [
         {
@@ -164,6 +180,30 @@ ruleTester.run('no-missing-remove-event-listener', (0, event_listener_1.createRu
                     data: {
                         eventName: 'click',
                         element: 'this.rootNodeRef',
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+      })
+      `,
+            errors: [
+                {
+                    messageId: 'missingRemoveEventListener',
+                    data: {
+                        eventName: 'data',
+                        element: 'emitter',
                     },
                 },
             ],

--- a/tests/src/rules/matching-remove-event-listener.ts
+++ b/tests/src/rules/matching-remove-event-listener.ts
@@ -72,6 +72,25 @@ ruleTester.run('matching-remove-event-listener', createRule(RuleType.MatchingRem
       }
     `,
     },
+    {
+      code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+      const data2Handler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.removeListener('data', dataHandler)
+      })
+      `,
+    },
   ],
   invalid: [
     {
@@ -211,6 +230,36 @@ ruleTester.run('matching-remove-event-listener', createRule(RuleType.MatchingRem
             remove: 'clickHandler',
             element: 'this.rootNodeRef',
             eventName: 'click',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+      const data2Handler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.removeListener('data', dataHandler2)
+      })
+      `,
+      errors: [
+        {
+          messageId: 'listenersDoNotMatch',
+          data: {
+            add: 'dataHandler',
+            remove: 'dataHandler2',
+            element: 'emitter',
+            eventName: 'data',
           },
         },
       ],

--- a/tests/src/rules/no-inline-function-event-listener.ts
+++ b/tests/src/rules/no-inline-function-event-listener.ts
@@ -44,6 +44,28 @@ ruleTester.run('inline-function-event-listener', createRule(RuleType.InlineFunct
       }
     `,
     },
+    {
+      code: `
+      const handleData = () => {
+        console.log('some data')
+      }
+      const handleError = (error) => {
+        console.log('some error', error)
+      }
+
+      class Handler {
+        constructor(private readonly emitter: EventEmitter) {
+          emitter.on('data', handleData)
+          emitter.on('error', handleError)
+        }
+
+        destroy() {
+          this.emitter.off('data', handleData)
+          this.emitter.off('error', handleError)       
+        }
+      }
+    `,
+    },
   ],
   invalid: [
     {
@@ -94,6 +116,37 @@ ruleTester.run('inline-function-event-listener', createRule(RuleType.InlineFunct
             element: 'this.rootNodeRef',
             eventName: 'tap',
             type: 'plain function',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      const handleData = () => {
+        console.log('some data')
+      }
+
+      class Handler {
+        constructor(private readonly emitter: EventEmitter) {
+          emitter.on('data', handleData)
+          emitter.on('error', (error) => {
+            console.log('some error', error)
+          })
+        }
+
+        destroy() {
+          this.emitter.off('data', handleData)
+          this.emitter.removeAllListeners()
+        }
+      }
+      `,
+      errors: [
+        {
+          messageId: 'prohibitedListener',
+          data: {
+            element: 'emitter',
+            eventName: 'error',
+            type: 'arrow function',
           },
         },
       ],

--- a/tests/src/rules/no-missing-remove-event-listener.ts
+++ b/tests/src/rules/no-missing-remove-event-listener.ts
@@ -67,6 +67,22 @@ ruleTester.run('no-missing-remove-event-listener', createRule(RuleType.MissingRe
     }
     `,
     },
+    {
+      code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.off('data', dataHandler)
+      })
+      `,
+    },
   ],
   invalid: [
     {
@@ -161,6 +177,30 @@ ruleTester.run('no-missing-remove-event-listener', createRule(RuleType.MissingRe
           data: {
             eventName: 'click',
             element: 'this.rootNodeRef',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+      })
+      `,
+      errors: [
+        {
+          messageId: 'missingRemoveEventListener',
+          data: {
+            eventName: 'data',
+            element: 'emitter',
           },
         },
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "noImplicitAny": true,
     "removeComments": true,
     "preserveConstEnums": true,
-    "target": "es2015",
-    "typeRoots": ["node_modules/@types"]
+    "target": "es2017",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   }
 }


### PR DESCRIPTION
Add support for `EventEmitter` `addListener`, `removeListener` and `removeAllListeners` functions as well as the `on` and `off` aliases.