### PR TITLE
Fix detecting removeAllListeners

### DIFF
--- a/src/rules/event-listener.ts
+++ b/src/rules/event-listener.ts
@@ -186,7 +186,7 @@ const programListener =
       const removeEvents = removeListeners[element];
       const removeAllEvents = removeAllListeners[element];
       Object.entries(addEvents).forEach(([eventName, { func, loc, hasUseCapture }]) => {
-        const event = removeEvents?.[eventName] ?? removeAllEvents?.[0];
+        const event = removeEvents?.[eventName] ?? removeAllEvents;
         switch (ruleName) {
           case RuleType.MissingRemoveEventListener:
             if (!event) {
@@ -201,7 +201,7 @@ const programListener =
             break;
 
           case RuleType.MatchingRemoveEventListener:
-            if (event && event.func !== func && event.func !== undefined) {
+            if (event && event.func !== func && event.func !== undefined && typeof event.func === 'string') {
               reportListenersDoNoMatch(context, element, eventName, func, event.func, loc, false);
             }
             if (event && event.func === func && hasUseCapture && !event.hasUseCapture && event.func !== undefined) {

--- a/tests/lib/src/rules/event-listener.js
+++ b/tests/lib/src/rules/event-listener.js
@@ -114,7 +114,7 @@ const programListener = (ruleName, listeners, context) => () => {
         const removeAllEvents = removeAllListeners[element];
         Object.entries(addEvents).forEach(([eventName, { func, loc, hasUseCapture }]) => {
             var _a;
-            const event = (_a = removeEvents === null || removeEvents === void 0 ? void 0 : removeEvents[eventName]) !== null && _a !== void 0 ? _a : removeAllEvents === null || removeAllEvents === void 0 ? void 0 : removeAllEvents[0];
+            const event = (_a = removeEvents === null || removeEvents === void 0 ? void 0 : removeEvents[eventName]) !== null && _a !== void 0 ? _a : removeAllEvents;
             switch (ruleName) {
                 case utils_1.RuleType.MissingRemoveEventListener:
                     if (!event) {
@@ -127,7 +127,7 @@ const programListener = (ruleName, listeners, context) => () => {
                     }
                     break;
                 case utils_1.RuleType.MatchingRemoveEventListener:
-                    if (event && event.func !== func && event.func !== undefined) {
+                    if (event && event.func !== func && event.func !== undefined && typeof event.func === 'string') {
                         reportListenersDoNoMatch(context, element, eventName, func, event.func, loc, false);
                     }
                     if (event && event.func === func && hasUseCapture && !event.hasUseCapture && event.func !== undefined) {

--- a/tests/lib/tests/src/rules/no-missing-remove-event-listener.js
+++ b/tests/lib/tests/src/rules/no-missing-remove-event-listener.js
@@ -86,6 +86,22 @@ ruleTester.run('no-missing-remove-event-listener', (0, event_listener_1.createRu
       })
       `,
         },
+        {
+            code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.removeAllListeners()
+      })
+      `,
+        },
     ],
     invalid: [
         {

--- a/tests/src/rules/no-missing-remove-event-listener.ts
+++ b/tests/src/rules/no-missing-remove-event-listener.ts
@@ -83,6 +83,22 @@ ruleTester.run('no-missing-remove-event-listener', createRule(RuleType.MissingRe
       })
       `,
     },
+    {
+      code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      
+      emitter.once('close', () => {
+        console.log('close')
+        emitter.removeAllListeners()
+      })
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
In my previous patch, the detection of the `removeAllListeners` call was not correct. This should fix that check. I also added a test for this check.