### PR TITLE
#9: Do not crash when no arguments are given to a remove function

### DIFF
--- a/src/rules/event-listener.ts
+++ b/src/rules/event-listener.ts
@@ -132,7 +132,9 @@ const callExpressionListener = (listeners: Listeners) => (node: TSESTree.CallExp
     if ([...ADD_LISTENERS, ...REMOVE_LISTENERS, ListenerType.REMOVE_ALL_LISTENERS].includes(listenerType)) {
       const element = parseMemberExpression(callee);
       const eventName =
-        ListenerType.REMOVE_ALL_LISTENERS !== listenerType ? (<TSESTree.Literal>node.arguments[0]).value : '_all_';
+        ListenerType.REMOVE_ALL_LISTENERS !== listenerType
+          ? (<TSESTree.Literal | undefined>node.arguments?.[0])?.value
+          : '_all_';
       const handler = <TSESTree.Expression>node.arguments[1];
 
       if (listenerType === ListenerType.ADD_EVENT_LISTENER) {
@@ -143,6 +145,10 @@ const callExpressionListener = (listeners: Listeners) => (node: TSESTree.CallExp
             return;
           }
         }
+      }
+
+      if (!eventName) {
+        return;
       }
 
       let func: string;

--- a/tests/lib/src/rules/event-listener.js
+++ b/tests/lib/src/rules/event-listener.js
@@ -62,22 +62,27 @@ const reportProhibitedListener = (context, element, eventName, type, loc) => {
     });
 };
 const callExpressionListener = (listeners) => (node) => {
-    var _a, _b, _c;
+    var _a, _b, _c, _d, _e;
     if ((0, utils_1.isNodeMemberExpression)(node.callee)) {
         const callee = node.callee;
         const listenerType = (_a = callee.property) === null || _a === void 0 ? void 0 : _a.name;
         if ([...ADD_LISTENERS, ...REMOVE_LISTENERS, ListenerType.REMOVE_ALL_LISTENERS].includes(listenerType)) {
             const element = (0, utils_1.parseMemberExpression)(callee);
-            const eventName = ListenerType.REMOVE_ALL_LISTENERS !== listenerType ? node.arguments[0].value : '_all_';
+            const eventName = ListenerType.REMOVE_ALL_LISTENERS !== listenerType
+                ? (_c = (_b = node.arguments) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.value
+                : '_all_';
             const handler = node.arguments[1];
             if (listenerType === ListenerType.ADD_EVENT_LISTENER) {
-                const params = (_c = (_b = node.arguments) === null || _b === void 0 ? void 0 : _b[2]) === null || _c === void 0 ? void 0 : _c.properties;
+                const params = (_e = (_d = node.arguments) === null || _d === void 0 ? void 0 : _d[2]) === null || _e === void 0 ? void 0 : _e.properties;
                 if (params && params.length) {
                     const isOnce = params.some((param) => param.key.name === 'once' && param.value.value);
                     if (isOnce) {
                         return;
                     }
                 }
+            }
+            if (!eventName) {
+                return;
             }
             let func;
             if ((0, utils_1.isNodeFunctionExpression)(handler)) {

--- a/tests/lib/tests/src/rules/no-missing-remove-event-listener.js
+++ b/tests/lib/tests/src/rules/no-missing-remove-event-listener.js
@@ -208,5 +208,29 @@ ruleTester.run('no-missing-remove-event-listener', (0, event_listener_1.createRu
                 },
             ],
         },
+        {
+            code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+      const data2Handler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      emitter.removeListener()
+      `,
+            errors: [
+                {
+                    messageId: 'missingRemoveEventListener',
+                    data: {
+                        eventName: 'data',
+                        element: 'emitter',
+                    },
+                },
+            ],
+        },
     ],
 });

--- a/tests/src/rules/no-missing-remove-event-listener.ts
+++ b/tests/src/rules/no-missing-remove-event-listener.ts
@@ -205,5 +205,29 @@ ruleTester.run('no-missing-remove-event-listener', createRule(RuleType.MissingRe
         },
       ],
     },
+    {
+      code: `
+      const emitter = new EventEmitter()
+
+      const dataHandler = () => {
+        console.log('data')
+      }
+      const data2Handler = () => {
+        console.log('data')
+      }
+
+      emitter.on('data', dataHandler)
+      emitter.removeListener()
+      `,
+      errors: [
+        {
+          messageId: 'missingRemoveEventListener',
+          data: {
+            eventName: 'data',
+            element: 'emitter',
+          },
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fix issue #9 which is caused by calling `removeListener` without arguments