### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:foad/eslint-plugin-listeners"
+    "url": "git+https://github.com/foad/eslint-plugin-listeners.git"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary

- Update the package `repository.url` from the SSH GitHub form to a public HTTPS URL.
- Leave runtime code, dependencies, package version, homepage, bugs metadata, source files, and compiled test fixtures unchanged.

## Why

This repository is public, so npm consumers should be able to follow the source repository link without SSH or GitHub key setup.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository?.url !== 'git+https://github.com/foad/eslint-plugin-listeners.git') throw new Error(JSON.stringify(p.repository))"`
- `git diff --check`
- `pnpm install --ignore-scripts --lockfile=false`
- local TypeScript adjusted to `5.2.2`, matching `yarn.lock`, because this Codex runtime does not include `yarn` or `corepack` and pnpm otherwise resolves `typescript@5.9.3`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (21 passing)
- `pnpm pack --dry-run`

No lockfile, dependency, or generated-file changes are included.
